### PR TITLE
Add HTTPS support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,6 @@ The properties to change are:
 
 After configuring Islandora's OpenSeadragon module, and making the changes to the properties above, you should be in business.  There are, of course, other configuration options documented on Djatoka's project page if you want to delve deeper. Feel free to ask me any questions that arise.
 
-### Processing requests from HTTPS-Islandora Sites
-When attempting to retrieve tiles from a JPEG2000 file retrieved from an HTTPS source (e.g. the location of the JPEG2000 file uses the 'https://' protocol), the freelib-djatoka server will return a 404-not-found error.  (See #64.)  A work-around is to proxy access through Apache and use mod_rewrite to change the query string.  For example:
-
-    RewriteCond %{QUERY_STRING} ^(.*)rft_id=https%3A%2F%2Fexample.org%2F(.*)$
-    RewriteRule /adore-djatoka/resolver http://localhost:8888/resolver?%1rft_id=http\%3A\%2F%\2Flocalhost\%2F%2 [P]
-    ProxyPassReverse /adore-djatoka/ http://localhost:8888/ nocanon
-
 ### License
 
 This package, freelib-djatoka, like its upstream project, aDORe-djatoka, is available under the LGPL license.

--- a/src/main/java/gov/lanl/adore/djatoka/util/IOUtils.java
+++ b/src/main/java/gov/lanl/adore/djatoka/util/IOUtils.java
@@ -125,9 +125,9 @@ public class IOUtils {
     }
 
     /**
-     * Gets an InputStream object for provide URL location
+     * Gets an InputStream object for provided URL location
      * 
-     * @param location File, http, or ftp URL to open connection and obtain InputStream
+     * @param location File, http(s), or ftp URL to open connection and obtain InputStream
      * @return InputStream containing the requested resource
      * @throws Exception
      */

--- a/src/main/java/info/freelibrary/djatoka/view/IdentifierResolver.java
+++ b/src/main/java/info/freelibrary/djatoka/view/IdentifierResolver.java
@@ -5,7 +5,9 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.net.URL;
 import java.net.URLDecoder;
+import java.net.MalformedURLException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -168,7 +170,12 @@ public class IdentifierResolver implements IReferentResolver, Constants {
     }
 
     private boolean isResolvableURI(final String aReferentID) {
-        return aReferentID.startsWith("http://") || aReferentID.startsWith("file://");
+        try {
+            final URL urlTest = new URL(aReferentID);
+            return true;
+        } catch (MalformedURLException details) {
+            return false;
+        }
     }
 
     private ImageRecord getCachedImage(final String aReferentID) {


### PR DESCRIPTION
Extend IdentifierResolver to be more inclusive

The isResolvalvableURI(String) method was extremely strict about the
schema of passed in links; namely it only considered http://(.*) and
file://(.*) to be valid.  This eliminates the ability to utilize
https or ftp schemas which are properly handled by the underlying
IOUtils getInputStream(URL) method.

* Utilizes java.net.URL to verify the string is (theoretically) valid
* Removes https only site workaround documentation

Resolves #64